### PR TITLE
Better attachment when not using id

### DIFF
--- a/lib/dbarrett:dropzonejs.js
+++ b/lib/dbarrett:dropzonejs.js
@@ -3,7 +3,7 @@ Template.dropzone.onRendered( function () {
   if ( this.data.id ) {
     this.dropzone = new Dropzone( '#' + this.data.id + '.dropzone', options );
   } else {
-    $( this.firstNode ).dropzone( options );
+    this.$('.dropzone').dropzone( options );
   }
 } );
 


### PR DESCRIPTION
Hey,

This seems like a more reliable technique of finding the dropzone div within the template (using without `id` wasn't working for me otherwise).